### PR TITLE
style: 💄/fix: 🐛 correction + composant de shadcn:

### DIFF
--- a/src/pages/profile/Favorite.tsx
+++ b/src/pages/profile/Favorite.tsx
@@ -1,7 +1,7 @@
 import { Meal } from "@/types/meal"
 import MealCard from "../search/MealCard"
 import MealCardListSkeleton from "@/components/skeleton/MealCardList"
-import { Separator } from "@radix-ui/react-separator"
+import { Separator } from "@/components/ui/separator"
 import { useAuthContext } from "@/hooks/useAuthContext"
 import { useRecipeList } from "@/commons/api/hooks/meal"
 

--- a/src/pages/profile/Profile.tsx
+++ b/src/pages/profile/Profile.tsx
@@ -1,5 +1,5 @@
 import { ProfileForm } from "@/components/form/profile"
-import { Separator } from "@radix-ui/react-separator"
+import { Separator } from "@/components/ui/separator"
 
 export default function Profile() {
   return (

--- a/src/pages/profile/SidebarNav.tsx
+++ b/src/pages/profile/SidebarNav.tsx
@@ -2,22 +2,19 @@ import { Link } from "@/components/ui/link"
 import { RouteProfileKeys } from "@/types/app"
 import { buttonVariants } from "@/components/ui/button/variants"
 import { cn } from "@/lib/utils"
-import { useState } from "react"
+import { getRoute } from "@/helpers"
+import { useLocation } from "react-router-dom"
 
 type SidebarNavProps = {
   className?: string
   items: {
-    href: RouteProfileKeys
+    route: RouteProfileKeys
     title: string
   }[]
 }
 
 export function SidebarNav({ className, items }: SidebarNavProps) {
-  const [pathname, setPathname] = useState("Profile")
-
-  const clickHandler = (page: string) => {
-    setPathname(page)
-  }
+  const { pathname } = useLocation()
 
   return (
     <nav
@@ -28,12 +25,11 @@ export function SidebarNav({ className, items }: SidebarNavProps) {
     >
       {items.map((item) => (
         <Link
-          to={item.href}
-          onClick={() => clickHandler(item.title)}
+          to={item.route}
           key={item.title}
           className={cn(
             buttonVariants({ variant: "ghost" }),
-            pathname === item.title
+            pathname === getRoute(item.route)
               ? "bg-muted hover:bg-muted"
               : "hover:bg-transparent hover:underline",
             "justify-start"

--- a/src/pages/profile/index.tsx
+++ b/src/pages/profile/index.tsx
@@ -3,16 +3,16 @@ import { RouteProfileKeys } from "@/types/app"
 import { Separator } from "@/components/ui/separator"
 import { SidebarNav } from "@/pages/profile/SidebarNav"
 
-type SidebarNavItemProps = { title: string; href: RouteProfileKeys }[]
+type SidebarNavItemProps = { title: string; route: RouteProfileKeys }[]
 
 const sidebarNavItems: SidebarNavItemProps = [
   {
     title: "Profile",
-    href: "profile",
+    route: "profile",
   },
   {
     title: "Favorite",
-    href: "favorite",
+    route: "favorite",
   },
 ]
 
@@ -21,7 +21,7 @@ export default function ProfileLayout() {
     <>
       <div className="space-y-6 p-10 pb-16 md:block">
         <div className="space-y-0.5">
-          <h2 className="text-2xl font-bold tracking-tight">Paramètres</h2>
+          <h2 className="text-2xl font-bold tracking-tight">Settings</h2>
           <p className="text-muted-foreground">
             Manage your account settings and set e-mail preferences.
           </p>
@@ -31,7 +31,7 @@ export default function ProfileLayout() {
           <aside className="-mx-4 lg:w-1/5">
             <SidebarNav items={sidebarNavItems} />
           </aside>
-          <div className="flex-1">
+          <div className="flex-1 lg:max-w-2xl">
             <Outlet />
           </div>
         </div>


### PR DESCRIPTION
- utilisation de react router pour réupérer le pathname
- utilisation de shadcn component au lieu de radix
- renommage de propriété